### PR TITLE
Add a new prop to enable scroll to end of a line chart.

### DIFF
--- a/examples/pure-chart/common.js
+++ b/examples/pure-chart/common.js
@@ -64,7 +64,7 @@ function getMaxValue (data) {
   return Math.max.apply(null, values)
 }
 
-export const initData = (dataProp, height, gap, numberOfPoints = 5) => {
+export const initData = (dataProp, height, gap, numberOfPoints = 5, maxValue) => {
   let guideArray, max, sortedData
   if (!dataProp || !Array.isArray(dataProp) || dataProp.length === 0) {
     return {
@@ -74,7 +74,7 @@ export const initData = (dataProp, height, gap, numberOfPoints = 5) => {
     }
   }
 
-  max = getMaxValue(dataProp)
+  max = Math.max(maxValue, getMaxValue(dataProp))
   guideArray = getGuideArray(max, height, numberOfPoints)
 
   dataProp = flattenData(dataProp)

--- a/examples/pure-chart/components/line-chart.js
+++ b/examples/pure-chart/components/line-chart.js
@@ -305,7 +305,13 @@ class LineChart extends React.Component {
           </View>
 
           <View>
-            <ScrollView horizontal>
+          <ScrollView
+              horizontal
+              ref={ref => this.scrollView = ref}
+              onContentSizeChange={() => {
+                if(this.props.lineChartScrollToEnd) this.scrollView.scrollToEnd({ animated: false });
+              }}
+          >
               <View>
 
                 <View ref='chartView' style={styles.chartViewWrapper}>

--- a/examples/pure-chart/components/line-chart.js
+++ b/examples/pure-chart/components/line-chart.js
@@ -5,7 +5,12 @@ import {initData, drawYAxis, drawGuideLine, drawYAxisLabels, numberWithCommas, d
 class LineChart extends React.Component {
   constructor (props) {
     super(props)
-    let newState = initData(this.props.data, this.props.height, this.props.gap, this.props.numberOfYAxisGuideLine)
+    let newState = initData(
+      this.props.data, 
+      this.props.height, 
+      this.props.gap, 
+      this.props.numberOfYAxisGuideLine,
+      this.props.maxValue)
     this.state = {
       loading: false,
       sortedData: newState.sortedData,
@@ -43,7 +48,7 @@ class LineChart extends React.Component {
     if (nextProps.data !== this.props.data) {
       this.setState(Object.assign({
         fadeAnim: new Animated.Value(0)
-      }, initData(nextProps.data, this.props.height, this.props.gap, this.props.numberOfYAxisGuideLine)), () => {
+      }, initData(nextProps.data, this.props.height, this.props.gap, this.props.numberOfYAxisGuideLine, this.props.maxValue)), () => {
         Animated.timing(this.state.fadeAnim, { toValue: 1, easing: Easing.bounce, duration: 1000, useNativeDriver: true }).start()
       })
     }
@@ -305,13 +310,12 @@ class LineChart extends React.Component {
           </View>
 
           <View>
-          <ScrollView
+            <ScrollView
               horizontal
               ref={ref => this.scrollView = ref}
               onContentSizeChange={() => {
                 if(this.props.lineChartScrollToEnd) this.scrollView.scrollToEnd({ animated: false });
-              }}
-          >
+              }}>
               <View>
 
                 <View ref='chartView' style={styles.chartViewWrapper}>


### PR DESCRIPTION
This is helpful in case of a long line chart and the user may be interested in seeing the latest data.