### PR TITLE
Ability to disable drawSelected rendering

### DIFF
--- a/examples/pure-chart/components/line-chart.js
+++ b/examples/pure-chart/components/line-chart.js
@@ -144,7 +144,7 @@ class LineChart extends React.Component {
     let key = 'point' + index
     let size = 8
     let color = !seriesColor ? this.props.primaryColor : seriesColor
-    if (this.state.selectedIndex === index) {
+    if (this.state.selectedIndex === index && this.props.drawSelected) {
       color = this.props.selectedColor
     }
 
@@ -232,6 +232,7 @@ class LineChart extends React.Component {
 
   drawSelected (index) {
     if (this.state.sortedData.length === 0) return null
+    if (!this.props.drawSelected) return null
     let data = this.state.sortedData[0].data
     let dataObject = data[index]
     if (typeof (this.state.selectedIndex) === 'number' && this.state.selectedIndex >= 0) {
@@ -355,7 +356,8 @@ LineChart.defaultProps = {
   onPointClick: (point) => {
 
   },
-  numberOfYAxisGuideLine: 5
+  numberOfYAxisGuideLine: 5,
+  drawSelected: true,
 }
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
Users will have the ability to not render selected point by setting new Prop "drawSelected" to false. 
The default prop is set to true. 
This changed is made so that onPress Prop will still work as usual even if drawSelected is false.

