### PR TITLE
Fix warning

### DIFF
--- a/examples/pure-chart/components/column-chart.js
+++ b/examples/pure-chart/components/column-chart.js
@@ -25,7 +25,7 @@ export default class ColumnChart extends Component {
     this.drawTooltip = this.drawTooltip.bind(this)
   }
 
-  componentWillReceiveProps (nextProps) {
+   componentDidUpdate (nextProps) {
     if (nextProps.data !== this.props.data) {
       this.setState(Object.assign({
         fadeAnim: new Animated.Value(0)

--- a/examples/pure-chart/components/line-chart.js
+++ b/examples/pure-chart/components/line-chart.js
@@ -58,7 +58,7 @@ class LineChart extends React.Component {
     }
   }
 
-  componentWillReceiveProps (nextProps) {
+  componentDidUpdate (nextProps) {
     if (nextProps.data !== this.props.data) {
       this.setState(Object.assign({
         fadeAnim: new Animated.Value(0)

--- a/examples/pure-chart/components/pie-chart.js
+++ b/examples/pure-chart/components/pie-chart.js
@@ -29,7 +29,7 @@ class PieChart extends React.Component {
     this.initData(this.props.data)
     Animated.timing(this.state.fadeAnim, { toValue: 1, easing: Easing.bounce, duration: 1000, useNativeDriver: true }).start()
   }
-  componentWillReceiveProps (nextProps) {
+  componentDidUpdate (nextProps) {
     if (nextProps.data !== this.props.data) {
       this.setState(Object.assign({
         fadeAnim: new Animated.Value(0)


### PR DESCRIPTION
Fix warning: "componentWillReceiveProps has been renamed and is not recommended for use”. componentWillReceiveProps is a synchronous hook. Calling asynchronous function like data fetching inside this hook will need to render in between when the new props are set and when data has finished loading.

Use componentDidUpdate to fix this.